### PR TITLE
Support template-haskell 2.17.

### DIFF
--- a/library/TemplateHaskell/Compat/V0208.hs
+++ b/library/TemplateHaskell/Compat/V0208.hs
@@ -23,7 +23,11 @@ instanceD =
   InstanceD
 #endif
 
+#if MIN_VERSION_template_haskell(2,17,0)
+dataD :: Cxt -> Name -> [TyVarBndr ()] -> [Con] -> [Name] -> Dec
+#else
 dataD :: Cxt -> Name -> [TyVarBndr] -> [Con] -> [Name] -> Dec
+#endif
 dataD cxt name varBndrs cons derivingNames =
 #if MIN_VERSION_template_haskell(2,12,0)
   DataD cxt name varBndrs Nothing cons (pure (DerivClause Nothing (map ConT derivingNames)))


### PR DESCRIPTION
Due to https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2465 (explicit specificty), `TyVarBndr` takes a type argument as of TH 2.17 (shipped with GHC 9.0), which is `()` in the usual case; see https://downloads.haskell.org/~ghc/9.0.1-alpha1/docs/html/libraries/template-haskell-2.17.0.0/Language-Haskell-TH.html#t:TyVarBndr.  This adds CPP to support this.