### PR TITLE
Proposal: Compatibility symbols for DoE, MDoE.

### DIFF
--- a/library/TemplateHaskell/Compat/V0208.hs
+++ b/library/TemplateHaskell/Compat/V0208.hs
@@ -68,3 +68,12 @@ type UnitTyVarBndr = TyVarBndr ()
 #else
 type UnitTyVarBndr = TyVarBndr
 #endif
+
+doE, mDoE :: [Stmt] -> Exp
+#if MIN_VERSION_template_haskell(2,17,0)
+doE = DoE Nothing
+mDoE = MDoE Nothing
+#else
+doE = DoE
+mDoE = MDoE
+#endif

--- a/library/TemplateHaskell/Compat/V0208.hs
+++ b/library/TemplateHaskell/Compat/V0208.hs
@@ -69,11 +69,9 @@ type UnitTyVarBndr = TyVarBndr ()
 type UnitTyVarBndr = TyVarBndr
 #endif
 
-doE, mDoE :: [Stmt] -> Exp
+doE :: [Stmt] -> Exp
 #if MIN_VERSION_template_haskell(2,17,0)
 doE = DoE Nothing
-mDoE = MDoE Nothing
 #else
 doE = DoE
-mDoE = MDoE
 #endif


### PR DESCRIPTION
In template-haskell 2.17, the `Exp` elements `DoE` and `MDoE` take a new `Maybe ModName` argument to support the `-XQualifiedDo` extension (https://downloads.haskell.org/~ghc/9.0.1-alpha1/docs/html/libraries/template-haskell-2.17.0.0/Language-Haskell-TH.html#g:20).  So far I have been dealing with this by using CPP, but it seems in the spirit of this package to add these as compatibility symbols.